### PR TITLE
Dockerfile and docker-compose.yml modified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,3 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && rm -fr /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN service ssh start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,20 +22,21 @@ services:
     build: .
     container_name: openssh-server
     hostname: openssh-server #optional
-    entrypoint:
-      - bash
+    entrypoint: /bin/bash -c "service ssh start && bash"
     tty: true
     stdin_open: true
+    restart: unless-stopped
+
 
   client-1:
-    image: debian
+    image: k23cz/openssh-client 
     entrypoint:
       - bash
     tty: true
     stdin_open: true
 
   client-2:
-    image: debian
+    image: k23cz/openssh-client 
     entrypoint:
       - bash
     tty: true


### PR DESCRIPTION
Good day Mr Oscar

I created a docker image with the openssh-client and vim packages running in a debian jessie distribution. The RUN option was deleted from Dockerfile beacuse it does not start the SSH service and the ENTRYPOINT option in docker-compose.yml was modified to start the SSH service.

Have a nice day.